### PR TITLE
fix: update Netlify file-based config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
 [build]
+  framework = "next"
   publish = ".next"
   command = "npm run build"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@netlify/plugin-nextjs": "^5.10.6",
         "eslint": "^9",
         "eslint-config-next": "15.3.0"
       }
@@ -617,6 +618,15 @@
         "@emnapi/core": "^1.4.0",
         "@emnapi/runtime": "^1.4.0",
         "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.10.6.tgz",
+      "integrity": "sha512-j/Jt/MMFy70f1LIa6qkviNWVoEIoF9ZICdDC3TF/IvStxWHGAYHm8pkqqbi1VqzjUEDUNu1ZGjo+VElZyenRBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@netlify/plugin-nextjs": "^5.10.6",
     "eslint": "^9",
     "eslint-config-next": "15.3.0"
   }


### PR DESCRIPTION
In normal cases when you use UI, Netlify automatically detects Next.js projects and adds the @netlify/plugin-nextjs plugin during the build process. But if you're creating a site programmatically using the REST API, we want to explicitly tell the plugin needed. 

The current `netlify.toml` deployment will not work correctly when we use the API. 